### PR TITLE
Faster implementation of backend sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,12 +43,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -246,39 +231,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gh-file-curler"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0294e40043cfda0c92fbe1dd58aefbe4cb265044c12d72a0120a5c9f09df3e5"
-dependencies = [
- "reqwest 0.11.27",
- "serde_json",
-]
-
-[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
-
-[[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
 
 [[package]]
 name = "h2"
@@ -291,7 +247,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -313,17 +269,6 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -335,23 +280,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -362,8 +296,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -374,42 +308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "hyper"
-version = "0.14.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
 name = "hyper"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,9 +316,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
- "http 1.1.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -436,8 +334,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.4.1",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -448,26 +346,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.30",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -484,9 +369,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.4.1",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -520,15 +405,6 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -620,18 +496,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "notoize"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119f1b144a396ba6385139b8b0bb266f54086fac5676e328f90b2cad09872a9c"
-dependencies = [
- "gh-file-curler",
- "itertools 0.12.1",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -756,93 +620,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
-
-[[package]]
-name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg 0.50.0",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.5",
- "http 1.1.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "hyper-rustls",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -852,11 +647,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -865,7 +660,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.52.0",
+ "winreg",
 ]
 
 [[package]]
@@ -917,20 +712,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "rustls-pki-types",
 ]
 
@@ -1052,11 +838,8 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 name = "soakue"
 version = "0.1.0"
 dependencies = [
- "humantime",
- "itertools 0.13.0",
- "notoize",
- "regex",
- "reqwest 0.12.5",
+ "itertools",
+ "reqwest",
  "serde",
  "serde_json",
  "unicode-normalization",
@@ -1094,12 +877,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -1530,16 +1307,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-humantime = "2.1.0"
 itertools = "0.13.0"
-notoize = "2.13.0"
-regex = "1.10.6"
 reqwest = { version = "0.12.5", features = ["blocking"] }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.122"

--- a/src/letters.rs
+++ b/src/letters.rs
@@ -1,0 +1,191 @@
+use std::{iter::Peekable, str::Chars};
+
+use crate::UNDERDOT;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    NotToaqChar(char),
+}
+
+// The characters we want to sort
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Letter {
+    Aomoi,
+    A,
+    B,
+    C,
+    Ch,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    Nh,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    Sh,
+    T,
+    U,
+    V,
+    Z,
+}
+
+impl Letter {
+    pub fn build_h_digraph(chr: char) -> Option<Self> {
+        match chr {
+            'c' => Some(Self::Ch),
+            'n' => Some(Self::Nh),
+            's' => Some(Self::Sh),
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<char> for Letter {
+    type Error = Error;
+
+    fn try_from(value: char) -> Result<Self, Self::Error> {
+        match value
+            .to_lowercase()
+            .next()
+            .expect("Lowercase should be single character")
+        {
+            '\'' => Ok(Self::Aomoi),
+            'a' => Ok(Self::A),
+            'b' => Ok(Self::B),
+            'c' => Ok(Self::C),
+            'd' => Ok(Self::D),
+            'e' => Ok(Self::E),
+            'f' => Ok(Self::F),
+            'g' => Ok(Self::G),
+            'h' => Ok(Self::H),
+            'i' | 'ı' => Ok(Self::I),
+            'j' => Ok(Self::J),
+            'k' => Ok(Self::K),
+            'l' => Ok(Self::L),
+            'm' => Ok(Self::M),
+            'n' => Ok(Self::N),
+            'o' => Ok(Self::O),
+            'p' => Ok(Self::P),
+            'q' => Ok(Self::Q),
+            'r' => Ok(Self::R),
+            's' => Ok(Self::S),
+            't' => Ok(Self::T),
+            'u' => Ok(Self::U),
+            'v' | 'w' | 'ꝡ' => Ok(Self::V),
+            'z' => Ok(Self::Z),
+            _ => Err(Error::NotToaqChar(value)),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Tone {
+    None,
+    Verb,
+    Noun,
+    Clause,
+    Adjunct,
+}
+
+/// A Toaq Grapheme
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Grapheme {
+    pub tone: Tone,
+    pub letter: Letter,
+    pub underdot: bool,
+}
+
+/// Encodes the possibility of failure or success of a Graphemes Iterator
+#[derive(Debug, PartialEq, Eq)]
+pub enum GraphResult {
+    Ok(Grapheme),
+    Err(Error),
+    Finished,
+}
+
+fn filter(x: &char) -> bool {
+    !x.is_whitespace() && !['*', '-', '.', ','].contains(x)
+}
+
+/// An "iterator" over a string's `Graph`emes. Returns `MaybeGraph` to encode the possibility of finishing with failure instead of succesful iteration.
+pub struct GraphsIter<'a> {
+    base: Peekable<Chars<'a>>,
+}
+
+impl<'a> GraphsIter<'a> {
+    pub fn new(string: &'a str) -> Self {
+        Self {
+            base: string.chars().peekable(),
+        }
+    }
+
+    pub fn next(&mut self) -> GraphResult {
+        let mut letter = None;
+
+        for char in self.base.by_ref() {
+            if filter(&char) {
+                letter = Some(char);
+                break;
+            }
+        }
+
+        let Some(letter) = letter else {
+            return GraphResult::Finished;
+        };
+
+        let letter = match letter {
+            'n' | 'c' | 's' => {
+                if self.base.next_if(|chr| *chr == 'h').is_some() {
+                    Letter::build_h_digraph(letter)
+                        .expect("UNREACHABLE: n, c and s all have digraphs")
+                } else {
+                    letter
+                        .try_into()
+                        .expect("UNREACHABLE: n, c and s are Toaq letters and should parse")
+                }
+            }
+            letter => match letter.try_into() {
+                Ok(letter) => letter,
+                Err(err) => return GraphResult::Err(err),
+            },
+        };
+
+        let mut tone = Tone::None;
+        let mut underdot = false;
+
+        // Tone and underdot characters are always after the letter.
+        self.base
+            .next_if(|next| tone_or_underdot(next, &mut tone, &mut underdot));
+        self.base
+            .next_if(|next| tone_or_underdot(next, &mut tone, &mut underdot));
+
+        GraphResult::Ok(Grapheme {
+            letter,
+            tone,
+            underdot,
+        })
+    }
+}
+
+/// Modifies `tone` and `underdot` if `chr` is either an underdot character or a tone character. Returns true only if this happens.
+fn tone_or_underdot(chr: &char, tone: &mut Tone, underdot: &mut bool) -> bool {
+    match chr {
+        '\u{0300}' => *tone = Tone::Verb,
+        '\u{0301}' => *tone = Tone::Noun,
+        '\u{0308}' => *tone = Tone::Clause,
+        '\u{0302}' => *tone = Tone::Adjunct,
+        &UNDERDOT => *underdot = true,
+        _ => return false,
+    }
+    true
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,14 @@
+mod letters;
 mod toadua;
 
 use crate::toadua::Toa;
 use crate::toadua::Toadua;
 use itertools::Itertools;
-use regex::bytes::Regex;
 use reqwest::blocking::Client;
 use serde_json::{from_str, to_string};
-use std::{fs, sync::LazyLock, time::Duration};
-use unicode_normalization::UnicodeNormalization;
+use std::{fs, time::Duration};
+
+const UNDERDOT: char = '\u{0323}';
 
 pub fn main() {
     let client = Client::builder()
@@ -42,154 +43,12 @@ pub fn main() {
     .unwrap();
 }
 
-static DOT_TONE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new("\u{0323}([\u{0301}\u{0302}\u{0308}])").unwrap());
-static PALATAL: LazyLock<Regex> = LazyLock::new(|| Regex::new("([ncsNCS])[hH]").unwrap());
-const TONES: &str = "\u{0300}\u{0301}\u{0308}\u{0302}";
-const CONSONANTS_STR: &str = "[bcdfghjklmnpqrstvz'ʰBCDFGHJKLMNPQRSTVZ]";
-const VOWELS_STR: &str = "[aeiouAEIOU]";
-// static CONSONANTS: LazyLock<Regex> = LazyLock::new(|| Regex::new(CONSONANTS_STR).unwrap());
-static VOWELS: LazyLock<Regex> = LazyLock::new(|| Regex::new(VOWELS_STR).unwrap());
-static FIND_STEM: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(&format!(
-        "[{TONES}]?\u{0323}({VOWELS_STR}*{CONSONANTS_STR}*{VOWELS_STR})"
-    ))
-    .unwrap()
-});
-
-static MADE_OF_RAKU: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new("^((^|[mpbfntdczsrljvkg'h ]|[ncs]ʰ)[aeiou]?([aeo]i|ao|[aeiou][qm]?)|[ .,?!()])+$")
-        .unwrap()
-});
-
 fn dictify(the: &str) -> Vec<Toa> {
-    let out = from_str::<Toadua>(the)
+    from_str::<Toadua>(the)
         .unwrap()
         .results
         .into_iter()
         .filter(|toa| toa.score >= -2)
-        .map(|toa| {
-            let tone_info = tones(&toa.head);
-            (
-                (
-                    tone_info.0,
-                    tone_info.1,
-                    tone_info.2,
-                    -toa.score,
-                    toa.clone().scope,
-                    toa.clone().date,
-                    toa.clone().body,
-                ),
-                toa,
-            )
-        })
-        .map(|(info, toa)| {
-            (
-                info.clone(),
-                Toa {
-                    warn: ([
-                        "ae", "au", "ou", "nʰi", "vi", "vu", "aiq", "aoq", "eiq", "oiq",
-                    ]
-                    .iter()
-                    .any(|v| info.0.contains(v))
-                        || !MADE_OF_RAKU.is_match(info.0.as_bytes())
-                        || toa.head.chars().any(|c| {
-                            !"aáäâạbcdeéëêẹfghıíïîịjklmnoóöôọpqrstuúüûụꝡz'\
-                              AÁÄÂẠBCDEÉËÊẸFGHIÍÏÎỊJKLMNOÓÖÔỌPQRSTUÚÜÛỤꝠZ \
-                              .,?!-\u{0323}()«»‹›\u{0301}\u{0308}\u{0302}"
-                                .contains(c)
-                        })
-                        || toa.user.starts_with("old"))
-                        && !toa.body.contains("textspeak")
-                        && !toa.notes.iter().any(|n| n.content.contains("textspeak")),
-                    ..toa
-                },
-            )
-        })
-        .sorted_by_key(|(info, _)| info.clone())
-        .map(|(_, toa)| toa)
-        .collect_vec();
-    out
-}
-
-pub fn tones(head: &str) -> (String, Vec<usize>, Vec<usize>) {
-    let head = String::from_utf8(
-        PALATAL
-            .replace_all(
-                &DOT_TONE.replace(
-                    head.nfd()
-                        .to_string()
-                        .to_lowercase()
-                        .trim_start_matches(|c| "*-@., ".contains(c))
-                        .chars()
-                        .map(|c| match c {
-                            'ı' => 'i',
-                            'ꝡ' => 'v',
-                            x => x,
-                        })
-                        .filter(|c| !"()".contains(*c))
-                        .collect::<String>()
-                        .as_bytes(),
-                    "$1\u{0323}".as_bytes(),
-                ),
-                "$1ʰ".as_bytes(),
-            )
-            .to_vec(),
-    )
-    .unwrap();
-    let mut tones = vec![];
-    let mut nat_indices = vec![];
-    let mut moved = vec![];
-    for word in head.split_whitespace() {
-        let mut tone = 1;
-        if !word.contains(|c| format!("\u{0323}{TONES}").contains(c)) {
-            moved.push(
-                String::from_utf8(
-                    VOWELS
-                        .replace(word.as_bytes(), "$0\u{0300}".as_bytes())
-                        .to_vec(),
-                )
-                .unwrap(),
-            );
-        } else if !word.contains("\u{0323}") {
-            moved.push(word.to_string());
-        }
-        for c in word.chars() {
-            if TONES.contains(c) {
-                tone = t2n(c);
-            }
-            if c == '\u{0323}' {
-                moved.push(
-                    String::from_utf8(
-                        FIND_STEM
-                            .replace(word.as_bytes(), format!("$1{}", n2t(tone)).as_bytes())
-                            .to_vec(),
-                    )
-                    .unwrap(),
-                );
-            }
-        }
-    }
-    let moved = moved.join(" ");
-    for (i, c) in moved.chars().enumerate() {
-        if TONES.contains(c) {
-            nat_indices.push(i - 1 - tones.len());
-            tones.push(t2n(c));
-        }
-    }
-    if moved.ends_with('-') {
-        *tones.iter_mut().last().unwrap() = 9;
-    }
-    let head = moved
-        .replace(|c| TONES.contains(c), "")
-        .trim_end_matches('-')
-        .to_string();
-    (head, tones, nat_indices)
-}
-
-fn t2n(c: char) -> usize {
-    TONES.chars().position(|t| t == c).unwrap() + 1
-}
-fn n2t(n: usize) -> char {
-    TONES.chars().nth(n - 1).unwrap()
+        .sorted_by(Toa::cmp)
+        .collect_vec()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,24 +37,7 @@ pub fn main() {
     .unwrap();
     fs::write(
         "data/readable.txt",
-        dict.iter()
-            .map(|toa| {
-                format!(
-                    "{}{} {} `{}` @{} #{}\n{}",
-                    if toa.warn { "⚠ " } else { "" },
-                    toa.head,
-                    match toa.score {
-                        0 => "±".to_string(),
-                        x if x > 0 => format!("+{}", toa.score),
-                        _ => toa.score.to_string(),
-                    },
-                    toa.scope,
-                    toa.user,
-                    toa.id,
-                    toa.body,
-                )
-            })
-            .join("\r\n\r\n"),
+        dict.iter().map(ToString::to_string).join("\r\n\r\n"),
     )
     .unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-#![allow(dead_code)]
+mod toadua;
 
+use crate::toadua::Toa;
+use crate::toadua::Toadua;
 use itertools::Itertools;
 use regex::bytes::Regex;
 use reqwest::blocking::Client;
-use serde::{Deserialize, Serialize};
 use serde_json::{from_str, to_string};
 use std::{fs, sync::LazyLock, time::Duration};
 use unicode_normalization::UnicodeNormalization;
@@ -208,28 +209,4 @@ fn t2n(c: char) -> usize {
 }
 fn n2t(n: usize) -> char {
     TONES.chars().nth(n - 1).unwrap()
-}
-
-#[derive(Deserialize, Serialize)]
-struct Toadua {
-    results: Vec<Toa>,
-}
-#[derive(Deserialize, Serialize, Clone)]
-struct Toa {
-    id: String,
-    date: String,
-    head: String,
-    body: String,
-    user: String,
-    notes: Vec<Note>,
-    score: i32,
-    scope: String,
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    warn: bool,
-}
-#[derive(Deserialize, Serialize, Clone)]
-struct Note {
-    date: String,
-    user: String,
-    content: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,19 +15,24 @@ pub fn main() {
         .timeout(Duration::from_secs(60))
         .build()
         .expect("Building client failed");
+
     let query = r#"{"action": "search", "query": ["and"]}"#.to_string();
+
     let res = client
         .post("https://toadua.uakci.space/api")
         .body(query)
         .send()
         .expect("Couldn't receive toadua's response");
+
     let text = res
         .text()
         .expect("Couldn't convert toadua's response to a string");
 
     let dict = dictify(&text);
     let dict_str = to_string(&dict).expect("Couldn't convert dictionary data to a string");
+
     fs::write("data/toakue.js", format!("const dict = {dict_str};")).unwrap();
+
     fs::write(
         "data/all.txt",
         dict.iter()
@@ -36,6 +41,7 @@ pub fn main() {
             .join("\r\n"),
     )
     .unwrap();
+
     fs::write(
         "data/readable.txt",
         dict.iter().map(ToString::to_string).join("\r\n\r\n"),

--- a/src/old_main.rs
+++ b/src/old_main.rs
@@ -1,0 +1,231 @@
+#![allow(dead_code)]
+
+use itertools::Itertools;
+use regex::bytes::Regex;
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{from_str, to_string};
+use std::{fs, sync::LazyLock, time::Duration};
+use unicode_normalization::UnicodeNormalization;
+
+pub fn main() {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(60))
+        .build()
+        .unwrap();
+    let query = r#"{"action": "search", "query": ["and"]}"#.to_string();
+    let res = client
+        .post("https://toadua.uakci.space/api")
+        .body(query)
+        .send();
+    let text = res.unwrap().text().unwrap();
+    let dict = dictify(&text);
+    let dict_str = to_string(&dict).unwrap();
+    fs::write("data/toakue.js", format!("const dict = {dict_str};")).unwrap();
+    fs::write(
+        "data/all.txt",
+        dict.iter()
+            .map(|toa| toa.head.clone())
+            .collect_vec()
+            .join("\r\n"),
+    )
+    .unwrap();
+    fs::write(
+        "data/readable.txt",
+        dict.iter()
+            .map(|toa| {
+                format!(
+                    "{}{} {} `{}` @{} #{}\n{}",
+                    if toa.warn { "⚠ " } else { "" },
+                    toa.head,
+                    match toa.score {
+                        0 => "±".to_string(),
+                        x if x > 0 => format!("+{}", toa.score),
+                        _ => toa.score.to_string(),
+                    },
+                    toa.scope,
+                    toa.user,
+                    toa.id,
+                    toa.body,
+                )
+            })
+            .join("\r\n\r\n"),
+    )
+    .unwrap();
+}
+
+static DOT_TONE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new("\u{0323}([\u{0301}\u{0302}\u{0308}])").unwrap());
+static PALATAL: LazyLock<Regex> = LazyLock::new(|| Regex::new("([ncsNCS])[hH]").unwrap());
+const TONES: &str = "\u{0300}\u{0301}\u{0308}\u{0302}";
+const CONSONANTS_STR: &str = "[bcdfghjklmnpqrstvz'ʰBCDFGHJKLMNPQRSTVZ]";
+const VOWELS_STR: &str = "[aeiouAEIOU]";
+// static CONSONANTS: LazyLock<Regex> = LazyLock::new(|| Regex::new(CONSONANTS_STR).unwrap());
+static VOWELS: LazyLock<Regex> = LazyLock::new(|| Regex::new(VOWELS_STR).unwrap());
+static FIND_STEM: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(
+        "[{TONES}]?\u{0323}({VOWELS_STR}*{CONSONANTS_STR}*{VOWELS_STR})"
+    ))
+    .unwrap()
+});
+
+static MADE_OF_RAKU: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new("^((^|[mpbfntdczsrljvkg'h ]|[ncs]ʰ)[aeiou]?([aeo]i|ao|[aeiou][qm]?)|[ .,?!()])+$")
+        .unwrap()
+});
+
+fn dictify(the: &str) -> Vec<Toa> {
+    let out = from_str::<Toadua>(the)
+        .unwrap()
+        .results
+        .into_iter()
+        .filter(|toa| toa.score >= -2)
+        .map(|toa| {
+            let tone_info = tones(&toa.head);
+            (
+                (
+                    tone_info.0,
+                    tone_info.1,
+                    tone_info.2,
+                    -toa.score,
+                    toa.clone().scope,
+                    toa.clone().date,
+                    toa.clone().body,
+                ),
+                toa,
+            )
+        })
+        .map(|(info, toa)| {
+            (
+                info.clone(),
+                Toa {
+                    warn: ([
+                        "ae", "au", "ou", "nʰi", "vi", "vu", "aiq", "aoq", "eiq", "oiq",
+                    ]
+                    .iter()
+                    .any(|v| info.0.contains(v))
+                        || !MADE_OF_RAKU.is_match(info.0.as_bytes())
+                        || toa.head.chars().any(|c| {
+                            !"aáäâạbcdeéëêẹfghıíïîịjklmnoóöôọpqrstuúüûụꝡz'\
+                              AÁÄÂẠBCDEÉËÊẸFGHIÍÏÎỊJKLMNOÓÖÔỌPQRSTUÚÜÛỤꝠZ \
+                              .,?!-\u{0323}()«»‹›\u{0301}\u{0308}\u{0302}"
+                                .contains(c)
+                        })
+                        || toa.user.starts_with("old"))
+                        && !toa.body.contains("textspeak")
+                        && !toa.notes.iter().any(|n| n.content.contains("textspeak")),
+                    ..toa
+                },
+            )
+        })
+        .sorted_by_key(|(info, _)| info.clone())
+        .map(|(_, toa)| toa)
+        .collect_vec();
+    out
+}
+
+pub fn tones(head: &str) -> (String, Vec<usize>, Vec<usize>) {
+    let head = String::from_utf8(
+        PALATAL
+            .replace_all(
+                &DOT_TONE.replace(
+                    head.nfd()
+                        .to_string()
+                        .to_lowercase()
+                        .trim_start_matches(|c| "*-@., ".contains(c))
+                        .chars()
+                        .map(|c| match c {
+                            'ı' => 'i',
+                            'ꝡ' => 'v',
+                            x => x,
+                        })
+                        .filter(|c| !"()".contains(*c))
+                        .collect::<String>()
+                        .as_bytes(),
+                    "$1\u{0323}".as_bytes(),
+                ),
+                "$1ʰ".as_bytes(),
+            )
+            .to_vec(),
+    )
+    .unwrap();
+    let mut tones = vec![];
+    let mut nat_indices = vec![];
+    let mut moved = vec![];
+    for word in head.split_whitespace() {
+        let mut tone = 1;
+        if !word.contains(|c| format!("\u{0323}{TONES}").contains(c)) {
+            moved.push(
+                String::from_utf8(
+                    VOWELS
+                        .replace(word.as_bytes(), "$0\u{0300}".as_bytes())
+                        .to_vec(),
+                )
+                .unwrap(),
+            );
+        } else if !word.contains("\u{0323}") {
+            moved.push(word.to_string());
+        }
+        for c in word.chars() {
+            if TONES.contains(c) {
+                tone = t2n(c);
+            }
+            if c == '\u{0323}' {
+                moved.push(
+                    String::from_utf8(
+                        FIND_STEM
+                            .replace(word.as_bytes(), format!("$1{}", n2t(tone)).as_bytes())
+                            .to_vec(),
+                    )
+                    .unwrap(),
+                );
+            }
+        }
+    }
+    let moved = moved.join(" ");
+    for (i, c) in moved.chars().enumerate() {
+        if TONES.contains(c) {
+            nat_indices.push(i - 1 - tones.len());
+            tones.push(t2n(c));
+        }
+    }
+    if moved.ends_with('-') {
+        *tones.iter_mut().last().unwrap() = 9;
+    }
+    let head = moved
+        .replace(|c| TONES.contains(c), "")
+        .trim_end_matches('-')
+        .to_string();
+    (head, tones, nat_indices)
+}
+
+fn t2n(c: char) -> usize {
+    TONES.chars().position(|t| t == c).unwrap() + 1
+}
+fn n2t(n: usize) -> char {
+    TONES.chars().nth(n - 1).unwrap()
+}
+
+#[derive(Deserialize, Serialize)]
+struct Toadua {
+    results: Vec<Toa>,
+}
+#[derive(Deserialize, Serialize, Clone)]
+struct Toa {
+    id: String,
+    date: String,
+    head: String,
+    body: String,
+    user: String,
+    notes: Vec<Note>,
+    score: i32,
+    scope: String,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    warn: bool,
+}
+#[derive(Deserialize, Serialize, Clone)]
+struct Note {
+    date: String,
+    user: String,
+    content: String,
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,1 @@
+use crate::old_main::{self, tones};

--- a/src/toadua.rs
+++ b/src/toadua.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+pub struct Toadua {
+    pub results: Vec<Toa>,
+}
+#[derive(Deserialize, Serialize, Clone)]
+pub struct Toa {
+    pub id: String,
+    pub date: String,
+    pub head: String,
+    pub body: String,
+    pub user: String,
+    pub notes: Vec<Note>,
+    pub score: i32,
+    pub scope: String,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub warn: bool,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub struct Note {
+    pub date: String,
+    pub user: String,
+    pub content: String,
+}

--- a/src/toadua.rs
+++ b/src/toadua.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
@@ -16,6 +18,26 @@ pub struct Toa {
     pub scope: String,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub warn: bool,
+}
+
+impl Display for Toa {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}{} {} `{}` @{} #{}\n{}",
+            if self.warn { "⚠ " } else { "" },
+            self.head,
+            match self.score {
+                0 => "±".to_string(),
+                x if x > 0 => format!("+{}", self.score),
+                _ => self.score.to_string(),
+            },
+            self.scope,
+            self.user,
+            self.id,
+            self.body,
+        )
+    }
 }
 
 #[derive(Deserialize, Serialize, Clone)]


### PR DESCRIPTION
This implementation is 4x faster. The only remaining bottleneck is sending API requests to toadua and receiving their response.

The objective of this PR is to make the backend code more readable as well as more efficient. It avoids doing unnecessary loops through the dictionary and its contents. It also makes use of standard trait implementations whenever possible (for example, Toa now implements Display for readable printing).

This is technically a breaking change in that the words are sorted slightly differently from before.