### PR TITLE
Updated subject notation in results list to match that used in Toadua

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -50,7 +50,7 @@ let htmlify = (json) =>
       " ",
       json.pronoun !== undefined ? mkel("span", { className: "adv" }, [makeLink("pron:" + json.pronoun, json.pronoun)]) : null,
       " ",
-      json.subject !== undefined ? mkel("span", { className: "adv" }, [makeLink("subj:" + json.subject[0], json.subject[0].toUpperCase())]) : null,
+      json.subject !== undefined ? mkel("span", { className: "adv" }, [makeLink("subj:" + json.subject[0], 's' + json.subject[0].toUpperCase())]) : null,
       " ",
       // mkel("br", {}, []),
       mkel("span", { className: "gray meta nobr" }, [


### PR DESCRIPTION
The notation for subject types has been changed in Toadua from A/F/E to sA/sF/sE, etc (see `#tooling` in Discord). This PR just aligns Sóakue's formatting with that change.

(LMK if I should have changed it somewhere else, too; I figured leaving the filter syntax as-as makes sense seeing as that's `subj:e` and the 's' in 'sE' stands for 'subj'.)